### PR TITLE
修复组织使用说明图标与文字重叠的bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 **/*.user
 *.suo
 *.sln.docstates
+/.vs

--- a/ClassScreenLock/Views/OrganizationView.axaml
+++ b/ClassScreenLock/Views/OrganizationView.axaml
@@ -325,19 +325,21 @@
                 Padding="24"
                 Background="{DynamicResource SystemControlBackgroundListLowBrush}"
                 CornerRadius="12">
-                <StackPanel Spacing="12">
+                 <StackPanel Spacing="12">
                     <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                         <fluent:SymbolIcon
                             Width="20"
                             Height="20"
                             VerticalAlignment="Center"
                             Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
-                            Symbol="Info" />
+                            Symbol="Info"
+                            Grid.Column="0"/>
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="16"
                             FontWeight="SemiBold"
-                            Text="{DynamicResource Organization_Usage_Title}" />
+                            Text="{DynamicResource Organization_Usage_Title}"
+                            Grid.Column="1"/>
                     </Grid>
                     <StackPanel Margin="8,0,0,0" Spacing="8">
                         <TextBlock Text="{DynamicResource Organization_Usage_1}" TextWrapping="Wrap" />


### PR DESCRIPTION
此PR修复了主界面组织管理页面关于使用说明的bug，基于[当前最新Release](github.com/ClassScreenLock/ClassScreenLock/releases/tag/V1.15.36.3545)。
原状况如xia下图所示。
<img width="111" height="50" alt="image" src="https://github.com/user-attachments/assets/e4182053-e282-473c-b380-d3d929353c6a" />
在加上这次PR后，状况如下图所示。
<img width="110" height="38" alt="image" src="https://github.com/user-attachments/assets/45c179c9-0217-4356-983d-a4e1decf3c1b" />
